### PR TITLE
Able to handle multiple dev ids

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(
     gstvmbsrc
-    VERSION 1.2.0
+    VERSION 1.3.0
     LANGUAGES C
     DESCRIPTION "GStreamer source plugin for VimbaX"
     HOMEPAGE_URL "https://alliedvision.com/"


### PR DESCRIPTION
There is an issue where the xml configuration file device id needs to match the camera device id. 
Using 'sed' to replace '__DEV__' in the config file with the device id read from the camera. 
This is a work around. Allied have indicated they are fixing this issue.